### PR TITLE
Fix typos in example command output

### DIFF
--- a/content/cli/help.md
+++ b/content/cli/help.md
@@ -69,7 +69,7 @@ SUBCOMMANDS:
   read                    Parse and print a Cooklang recipe file
   validate                Check for syntax errors in one or more Cooklang recipe files (TODO)
   prettify                Edit a Cooklang recipe file for style consistency (TODO)
-  image                   Download a random image from upsplash.com to match the recipe title
+  image                   Download a random image from unsplash.com to match the recipe title
 
   See 'cook help recipe <subcommand>' for detailed help.
 ```
@@ -112,7 +112,7 @@ Edit the content of a Cooklang recipe file for style consistency
 ### `image`
 
 ```
-OVERVIEW: Download a random image from upsplash.com to match the recipe title
+OVERVIEW: Download a random image from unsplash.com to match the recipe title
 
 USAGE: cook recipe image <file>
 


### PR DESCRIPTION
They are technically not incorrect as of CookCLI v0.1.0, but after the next release (which will contain my changes from earlier today) the examples will display a different url. Maybe hold off on merging until the next release.