### PR TITLE
Add micro syntax and link to awesome cooklang recipes

### DIFF
--- a/content/docs/examples.md
+++ b/content/docs/examples.md
@@ -25,4 +25,4 @@ Once golden underneath, flip the pancake over and cook for 1 further minute, or 
 Serve straightaway with your favourite topping. -- Add your favorite topping here to make sure it's included in your meal plan!
 ```
 
-More examples https://github.com/Cooklang/spec/tree/main/examples or in [Community recipes](https://github.com/Cooklang/recipes)
+More examples https://github.com/Cooklang/spec/tree/main/examples, [Community recipes](https://github.com/Cooklang/recipes) or in [Awesome Cooklang Recipes](https://github.com/cooklang/awesome-cooklang-recipes)

--- a/content/docs/syntax-highlighting.md
+++ b/content/docs/syntax-highlighting.md
@@ -8,6 +8,7 @@ summary: Instructions for installing syntax highlighting addons for some of the 
 If you would like to install a Cooklang syntax highlighting addon for your favorite text editor, here are the instructions for the programs we support.
 
 * [Emacs via GitHub](#emacs-via-github)
+* [Micro via GitHub](#micro-via-github)
 * [Nano via GitHub](#nano-via-github)
 * [Sublime via Package Control](#sublime-via-package-control)
 * [Vim via GitHub](#vim-via-github)
@@ -16,6 +17,10 @@ If you would like to install a Cooklang syntax highlighting addon for your favor
 ## Emacs via GitHub
 
 * [Install from here](https://github.com/cooklang/cook-mode)
+
+## Micro via GitHub
+
+* [Install from here](https://github.com/nicholaswilde/cooklang-micro)
 
 ## Nano via GitHub
 


### PR DESCRIPTION
Add links to [cooklang-micro](https://github.com/nicholaswilde/cooklang-micro) syntax highlighting and [awesome cooklang recipes](https://github.com/cooklang/awesome-cooklang-recipes).