### PR TITLE
✅ Mark .NET implementation as passing canon tests

### DIFF
--- a/content/docs/for-developers.md
+++ b/content/docs/for-developers.md
@@ -13,7 +13,7 @@ Formal EBNF definition of the language can be found [here](https://github.com/co
 * [Tree-sitter](https://github.com/addcninblue/tree-sitter-cooklang)
 
 ### Parser implementations
-* [.NET](https://github.com/heytherewill/cooklangnet)
+* [.NET](https://github.com/heytherewill/cooklangnet) ✅
 * [C](https://github.com/cooklang/cook-in-c)
 * [Clojure](https://github.com/kiranshila/cooklang-clj)
 * [Dart](https://github.com/aquilax/cooklang-dart) ✅


### PR DESCRIPTION
Since release 0.3 the .NET parser now [passes canonical tests](https://github.com/heytherewill/CookLangNet/commit/a58280421e4b2be76a27cb26a72a1b7b5e898c90)