### PR TITLE
Correct link to awesome recipes repo

### DIFF
--- a/content/docs/getting-started.md
+++ b/content/docs/getting-started.md
@@ -92,7 +92,7 @@ If you have some problems and your recipe doesn't render as you want, you can ch
 
 Find curated Cooklang recipes from the community, share your thoughts or ask for help. Some resources include:
 
-- The [Awesome Cooklang](https://github.com/cooklang/awesome-cooklang) repository
+- The [Awesome Cooklang](https://github.com/cooklang/awesome-cooklang-recipes) repository
 - The [Cooklang Recipe Hub](https://cook.md) (coming soon!)
 - Community language [discussions](https://github.com/cooklang/spec/discussions) and [Discord channel](https://discord.gg/fUVVvUzEEK)
 


### PR DESCRIPTION
Thanks for open sourcing your work, while browsing I probably stumbled upon a dead link

I think the awesome-cooklang repo at one time moved to awesome-cooklang-recipes, my PR should fix the link