### PR TITLE
Update rpi use case docs

### DIFF
--- a/content/docs/use-cases/raspberry-pi.md
+++ b/content/docs/use-cases/raspberry-pi.md
@@ -370,9 +370,6 @@ server {
 ```
 
 ```bash
-# Disable default site
-sudo unlink /etc/nginx/sites-enabled/default
-
 # Enable site
 sudo ln -s /etc/nginx/sites-available/cooklang /etc/nginx/sites-enabled/
 sudo nginx -t


### PR DESCRIPTION
I recently went through deploying cooklang to a raspberry pi. The docs were helpful but I had to make the below changes.

Changes:
* `cook server --host` no longer takes `0.0.0.0` as an argument
* Removed "Solution 2" in "Problem: Cannot Connect from Other Devices" of troublshooting. I believe this is no longer relevant from the above

Not sure guidelines on contributing to documentation so happy to remove PR or change any formatting to comply.