### PR TITLE
Link "`.menu` files" to "Meal Planning" page

### DIFF
--- a/content/cli/commands/recipe.md
+++ b/content/cli/commands/recipe.md
@@ -24,7 +24,7 @@ This displays the recipe in a human-readable format with ingredients, steps, and
 
 ## Menu Files
 
-CookCLI also supports `.menu` files for meal planning. Menu files can reference multiple recipes and organize them by meals or days:
+CookCLI also supports [`.menu` files](/docs/use-cases/meal-planning/) for meal planning. Menu files can reference multiple recipes and organize them by meals or days:
 
 ```bash
 # View a menu file

--- a/content/cli/commands/shopping-list.md
+++ b/content/cli/commands/shopping-list.md
@@ -75,7 +75,7 @@ cook shopping-list "Main Course.cook:2" "Side Dish.cook:2" "Dessert.cook:2"
 
 ## Menu Files
 
-Create shopping lists from `.menu` files that organize multiple recipes:
+Create shopping lists from [`.menu` files](/docs/use-cases/meal-planning/) that organize multiple recipes:
 
 ```bash
 # Generate shopping list from weekly menu


### PR DESCRIPTION
The CLI docs contain two references to `.menu` files, but these references are not accompanied by descriptions of how such files work, and it takes some clicking around on the site to find the actual description on the "Meal Planning" page.  This PR solves this by making the mentions of `.menu` files into hyperlinks to the "Meal Planning" page.