### PR TITLE
SEO: blog meta descriptions, nutrients retitle, internal + cross-site links

### DIFF
--- a/content/blog/01-my-approach-to-automating-grocery-shopping.md
+++ b/content/blog/01-my-approach-to-automating-grocery-shopping.md
@@ -3,6 +3,7 @@ title: 'How to Automate Grocery Shopping with Plain Text Recipes'
 date: 2026-04-09
 weight: 100
 summary: How I automated my grocery shopping by creating Cooklang — a markup language that turns recipe files into shopping lists. From sticky notes to command-line automation.
+description: "Automate your grocery shopping with plain-text recipes. How Cooklang turns .cook files into shopping lists automatically — from sticky notes to the command line."
 categories: ["Recipe Workflows"]
 ---
 

--- a/content/blog/02-practical-savings-on-groceries-with-cooklang.md
+++ b/content/blog/02-practical-savings-on-groceries-with-cooklang.md
@@ -3,6 +3,7 @@ title: 'Automated Grocery List: Save Time and Money with Meal Planning'
 date: 2026-04-09
 weight: 90
 summary: Build an automated grocery list from your meal plan using Cooklang. Practical tips for shopping list automation, reducing food waste, and cutting your grocery bill.
+description: "Build an automated grocery list from your meal plan with Cooklang. Cut food waste and your grocery bill using plain-text shopping-list automation."
 categories: ["Recipe Workflows"]
 ---
 

--- a/content/blog/03-ai-and-the-evolution-of-recipe-formats.md
+++ b/content/blog/03-ai-and-the-evolution-of-recipe-formats.md
@@ -3,6 +3,7 @@ title: 'Generating a Recipe Graph with ChatGPT'
 date: 2023-05-26T19:27:37+10:00
 weight: 80
 summary: "Using GPT-4 to trace ingredients through cooking steps and generate a recipe graph — a visual representation of how raw ingredients transform into a finished dish."
+description: "Using GPT-4 to trace ingredients through cooking steps and build a recipe graph — how AI and structured data are reshaping recipe formats."
 categories: ["Format and Design"]
 ---
 

--- a/content/blog/05-recipes-as-stack-machines.md
+++ b/content/blog/05-recipes-as-stack-machines.md
@@ -3,6 +3,7 @@ title: "Recipe Algorithms: How Recipes Work Like Computer Programs"
 date: 2024-11-29
 weight: 80
 summary: "Every recipe is an algorithm — a sequence of operations transforming inputs into output. Here's the formal model behind cooking instructions, why it matters for recipe validation and automation, and how Cooklang uses it."
+description: "Every recipe is an algorithm. The formal stack-machine model behind cooking instructions, and how Cooklang uses it for recipe validation and automation."
 categories: ["Format and Design"]
 ---
 

--- a/content/blog/06-developing-file-sync-library.md
+++ b/content/blog/06-developing-file-sync-library.md
@@ -3,6 +3,7 @@ title: "Developing file sync library"
 date: 2024-11-29
 weight: 80
 summary: Alexey on a quest of solving recipe sync problem for Cooklang apps.
+description: "How we built a file-sync library for plain-text Cooklang recipes — the design problems behind syncing .cook files across devices without lock-in."
 categories: ["Self-Hosting and Integrations"]
 ---
 

--- a/content/blog/07-nutrients-during-cooking.md
+++ b/content/blog/07-nutrients-during-cooking.md
@@ -1,9 +1,9 @@
 ---
-title: "What Recipe Software Should Tell You About Nutrition"
+title: "Does Cooking Destroy Nutrients? What Structured Recipes Could Tell You"
 date: 2024-12-16
 weight: 80
 summary: "Cooking method changes nutrition as much as the ingredients do. Recipe apps know neither. Here's what structured recipe data could finally make possible."
-description: "Cooking method changes nutrition as much as the ingredients do. Recipe apps know neither. Here's what structured recipe data could finally make possible."
+description: "Boiling broccoli for 10 minutes destroys ~50% of its vitamin C; steaming almost none. Why cooking method changes nutrition as much as the ingredients do — and what helps."
 categories: ["Format and Design"]
 ---
 

--- a/content/blog/09-cooklang-vs-paprika-vs-mealie.md
+++ b/content/blog/09-cooklang-vs-paprika-vs-mealie.md
@@ -3,6 +3,7 @@ title: "Mealie vs Paprika vs KitchenOwl vs Cooklang: Recipe Manager Comparison (
 date: 2025-01-04
 weight: 90
 summary: "Comparing four popular recipe management solutions — the open-source self-hosted Mealie, the polished commercial Paprika, the household-friendly KitchenOwl, and the plain-text Cooklang. An honest look at what each does best and which fits your cooking workflow."
+description: "Mealie vs Paprika vs KitchenOwl vs Cooklang, compared honestly (2026). What each recipe manager does best — self-hosted, commercial, or plain-text."
 categories: ["Comparisons"]
 ---
 
@@ -63,7 +64,7 @@ If you're weighing Paprika specifically against an own-your-data approach with A
 
 ### Mealie: The Self-Hosted Revolution
 
-Mealie asks a different question: Why should a tech company own your family recipes?
+Mealie asks a different question: Why should a tech company own your family recipes? (We take a closer look in our full [Mealie review](/blog/40-mealie-review/).)
 
 Running on your own server (or a $5/month VPS), Mealie gives you Instagram-worthy recipe management without Instagram owning your data.
 

--- a/content/blog/18-open-source-recipe-managers-2026.md
+++ b/content/blog/18-open-source-recipe-managers-2026.md
@@ -32,7 +32,7 @@ Here's an honest look at the main options.
 
 ## Mealie
 
-[Mealie](https://mealie.io/) is a self-hosted web application focused on recipe management and meal planning. It runs as a Docker container and provides a polished web interface.
+[Mealie](https://mealie.io/) is a self-hosted web application focused on recipe management and meal planning. It runs as a Docker container and provides a polished web interface. (For a deeper look, see our full [Mealie review](/blog/40-mealie-review/).)
 
 **Strengths:**
 - Polished UI — looks good, easy to use

--- a/content/blog/20-save-recipes-from-social-media.md
+++ b/content/blog/20-save-recipes-from-social-media.md
@@ -43,6 +43,8 @@ cook import "https://example.com/the-recipe"
 
 This downloads the recipe and converts it to Cooklang format automatically.
 
+**Using AI import (screenshots and captions):** For recipes that only exist in a Reel or a screenshot, [Cook's Cookify](https://cook.md/blog/import-recipes-from-instagram) turns an Instagram caption or screenshot into a clean, structured recipe file — no retyping.
+
 ### Step 2: Write It in Cooklang
 
 Convert the recipe into a [Cooklang](/docs/spec/) file — a plain text format where ingredients, cookware, and timers are annotated inline:

--- a/content/blog/23-complete-cookcli-guide.md
+++ b/content/blog/23-complete-cookcli-guide.md
@@ -3,6 +3,7 @@ title: "The Complete CookCLI Guide: From Install to Daily Use"
 date: 2026-02-28
 weight: 60
 summary: "A hands-on walkthrough of CookCLI covering installation, parsing recipes, generating shopping lists, scaling servings, and every command you'll actually use."
+description: "The complete CookCLI guide: install CookCLI, parse recipes, generate shopping lists, and scale servings from the command line. Every command you'll actually use."
 categories: ["Guides and Tutorials"]
 ---
 

--- a/content/blog/28-migrating-recipes-to-cooklang.md
+++ b/content/blog/28-migrating-recipes-to-cooklang.md
@@ -3,6 +3,7 @@ title: "Migrating Your Recipes to Cooklang (From Any App or Format)"
 date: 2026-02-28
 weight: 60
 summary: "Stuck in a recipe app you can't escape? Here's how to migrate your recipes to plain .cook files from websites, Paprika, Mealie, photos, and Markdown — without doing it all at once."
+description: "How to migrate your recipes to Cooklang plain-text .cook files — from Paprika, Mealie, websites, photos, and Markdown, without doing it all at once."
 categories: ["Guides and Tutorials"]
 ---
 

--- a/content/blog/29-building-recipe-api-with-cooklang.md
+++ b/content/blog/29-building-recipe-api-with-cooklang.md
@@ -3,6 +3,7 @@ title: "Building a Recipe API with Cooklang"
 date: 2026-02-28
 weight: 60
 summary: "Skip the third-party recipe APIs. With CookCLI, your plain-text .cook files become a structured JSON backend you own and control."
+description: "Build a recipe API with CookCLI: turn your plain-text .cook files into a structured JSON backend you own — no third-party recipe API required."
 categories: ["Self-Hosting and Integrations"]
 ---
 

--- a/content/blog/37-designing-a-recipe-markup-language.md
+++ b/content/blog/37-designing-a-recipe-markup-language.md
@@ -3,6 +3,7 @@ title: "What Goes Into Designing a Recipe Markup Language"
 date: 2026-03-24
 weight: 50
 summary: "Recipes are one of the most structured forms of human writing, yet almost every digital format either loses that structure or buries it in machine syntax. Here's how we designed a markup language that keeps recipes readable and machine-parseable at the same time."
+description: "How we designed the Cooklang recipe markup language to keep recipes both human-readable and machine-parseable — the trade-offs behind the format."
 categories: ["Format and Design"]
 ---
 

--- a/content/blog/40-mealie-review.md
+++ b/content/blog/40-mealie-review.md
@@ -3,6 +3,7 @@ title: "Mealie Review: A Developer's Honest Look at the Self-Hosted Recipe Manag
 date: 2026-03-24
 weight: 45
 summary: "Mealie is one of the most popular self-hosted recipe managers. Here's an honest look at what it does well, where it falls short, and who it's actually for — from someone who builds a different kind of recipe tool."
+description: "Mealie review: an honest developer's look at the popular self-hosted recipe manager — what it does well, where it frustrates, and who it's really for."
 categories: ["Comparisons"]
 ---
 

--- a/content/blog/42-tandoor-vs-mealie-vs-kitchenowl.md
+++ b/content/blog/42-tandoor-vs-mealie-vs-kitchenowl.md
@@ -15,7 +15,7 @@ Mealie optimizes for polish and ease of use. Tandoor optimizes for features and 
 
 ## Quick Overview
 
-**Mealie** ([github.com/mealie-recipes/mealie](https://github.com/mealie-recipes/mealie)) is a Python/FastAPI backend with a Vue.js frontend. It is probably the most approachable of the three — the UI is clean, web scraping works well, and the API is documented via OpenAPI. SQLite by default, PostgreSQL if you need it. Large community, frequent releases.
+**Mealie** ([github.com/mealie-recipes/mealie](https://github.com/mealie-recipes/mealie)) is a Python/FastAPI backend with a Vue.js frontend. It is probably the most approachable of the three — the UI is clean, web scraping works well, and the API is documented via OpenAPI. SQLite by default, PostgreSQL if you need it. Large community, frequent releases. (See our full [Mealie review](/blog/40-mealie-review/) for a closer look.)
 
 **Tandoor Recipes** ([github.com/TandoorRecipes/recipes](https://github.com/TandoorRecipes/recipes)) is a Django + Vue.js application that requires PostgreSQL. It is the most feature-rich option here: keyword and tag systems, import/export in multiple formats, granular permissions, nutritional tracking, and meal cost calculation. The trade-off is complexity — more to configure, more to learn.
 


### PR DESCRIPTION
From the 2026-07-01 growth check-in (GSC CTR/position analysis). All content-only (front matter + body links); no CSS/layout changes, so no Hugo CSS rebuild needed.

## Changes
- **Meta descriptions** added to 11 high-impression posts that had none (they were falling back to a truncated auto-summary → weak SERP snippets): `01, 02, 03, 05, 06, 09, 23, 28, 29, 37, 40`.
- **`07-nutrients-during-cooking` retitled** — it pulls ~15k impressions at **0.05% CTR** from "does steaming/boiling broccoli remove nutrients" queries, but the old title ("What Recipe Software Should Tell You About Nutrition") mismatched that intent. New title + description lead with the nutrient-retention answer the intro already gives.
- **Internal links** to `40-mealie-review` from the Mealie-heavy comparison posts (`09`, `18`, `42`) to lift the `mealie` / `mealie review` pages (pos 6–7).
- **Cross-site link**: `20-save-recipes-from-social-media` → cook.md's Instagram-import (Cookify) post — on-strategy per the lane split (funnels cooklang.org authority to cook.md).

## Review notes
- No new posts (comparison inventory already exists; avoided cannibalization).
- Descriptions are ≤~160 chars, keyword-led, and accurate to each post's existing summary.