### PR TITLE
Fix duplicate heading on contact page

### DIFF
--- a/content/contact.md
+++ b/content/contact.md
@@ -3,8 +3,6 @@ title: "Contact"
 layout: "single"
 ---
 
-# Get in Touch
-
 We'd love to hear from you — whether you've found a bug, have a question, want to share a recipe workflow, or just want to say hello.
 
 ## Community


### PR DESCRIPTION
The `_default/single.html` layout already renders the page title ("Contact") as an `<h1>`. The contact page content also opened with a `# Get in Touch` H1, producing two stacked headers. Removed the redundant in-content heading; the layout title is now the single page header.