### PR TITLE
SEO: descriptions for the remaining 19 posts + 2 title tweaks

### DIFF
--- a/content/blog/08-david-a-mundie-interview.md
+++ b/content/blog/08-david-a-mundie-interview.md
@@ -3,6 +3,7 @@ title: "David A. Mundie on Cooking and Technology"
 date: 2024-12-26
 weight: 80
 summary: "An interview with David A. Mundie, creator of RxOL - the first programming language for recipes in 1985. He shares his vision of simplifying cooking through technology, his thoughts on recipe formats, and perspectives on the future of kitchen automation."
+description: "David A. Mundie, creator of RxOL (1985) — the first recipe programming language — on recipe formats, simplifying cooking with technology, and the future of the kitchen."
 categories: ["Format and Design"]
 ---
 

--- a/content/blog/12-why-plain-text-recipes.md
+++ b/content/blog/12-why-plain-text-recipes.md
@@ -3,6 +3,7 @@ title: "Why Plain Text Recipes Beat Databases Every Time"
 date: 2025-01-20
 weight: 70
 summary: "After years of building recipe apps with databases, I discovered that plain text files solve the real problems better. Here's why the future of digital recipes isn't in the cloud - it's in your text editor."
+description: "After years building database recipe apps, why plain-text .cook files solve the real problems better — the case for recipes in a text editor, not the cloud."
 categories: ["Format and Design"]
 ---
 

--- a/content/blog/13-the-dishwasher-salmon-problem.md
+++ b/content/blog/13-the-dishwasher-salmon-problem.md
@@ -3,6 +3,7 @@ title: "The Dishwasher Salmon Problem"
 date: 2025-10-26
 weight: 60
 summary: "Recipe blogs prioritize ads over quality, creating bizarre dishes like dishwasher salmon. Cooklang Federation solves this by connecting you to tried and true community recipes."
+description: "Recipe blogs prioritise ads over quality, spawning oddities like dishwasher salmon. How the Cooklang Federation connects you to tried-and-true community recipes instead."
 categories: ["Recipe Workflows"]
 ---
 

--- a/content/blog/14-greedy-coverage-blog.md
+++ b/content/blog/14-greedy-coverage-blog.md
@@ -3,6 +3,7 @@ title: "Building the Perfect Pantry with CookCLI: How the Greedy Coverage Algori
 date: 2025-12-06
 weight: 60
 summary: "A practical deep dive into how CookCLI uses algorithmic coverage analysis to help users build the most efficient pantry for their recipe collection."
+description: "How CookCLI's greedy coverage algorithm analyses your recipe collection to help you build the most efficient pantry — a practical, worked deep dive."
 categories: ["Recipe Workflows"]
 ---
 

--- a/content/blog/16-recipe-discovery-without-ads.md
+++ b/content/blog/16-recipe-discovery-without-ads.md
@@ -3,6 +3,7 @@ title: "Recipe Discovery Without the Ads and Life Stories"
 date: 2026-02-25
 weight: 60
 summary: "Modern recipe sites bury recipes under ads, pop-ups, and SEO filler. Cooklang Federation offers a different approach — a searchable index of community-tested recipes with no ads, no tracking, and no stories about someone's trip to Tuscany."
+description: "Recipe sites bury recipes under ads and SEO filler. The Cooklang Federation is a searchable index of community-tested recipes — no ads, no tracking, no life stories."
 categories: ["Recipe Workflows"]
 ---
 

--- a/content/blog/20-save-recipes-from-social-media.md
+++ b/content/blog/20-save-recipes-from-social-media.md
@@ -3,6 +3,7 @@ title: "How to Save Recipes from Social Media and Keep Them Forever"
 date: 2026-02-25
 weight: 60
 summary: "Recipes you save on Instagram, TikTok, and Facebook disappear when creators delete posts or platforms change. Here's a workflow to capture social media recipes and store them permanently as plain text files you control."
+description: "Save recipes from Instagram, TikTok, and Facebook before they vanish — a workflow to capture them as permanent plain-text files you control."
 categories: ["Recipe Workflows"]
 ---
 

--- a/content/blog/22-cooking-for-programmers.md
+++ b/content/blog/22-cooking-for-programmers.md
@@ -3,6 +3,7 @@ title: "Recipe Programming Language — Write and Manage Recipes as Code"
 date: 2026-02-25
 weight: 60
 summary: "Cooklang is a programming language for recipes. Declare ingredients as typed variables, generate shopping lists automatically, scale servings with a command, and version-control your cookbook with Git. Here's how recipes and code are the same thing — and why that matters."
+description: "Cooklang treats recipes as code — typed ingredients, auto shopping lists, one-command scaling, Git-versioned cookbooks. Why recipes and code are the same thing."
 categories: ["Format and Design"]
 ---
 

--- a/content/blog/25-publishing-recipe-collection-as-website.md
+++ b/content/blog/25-publishing-recipe-collection-as-website.md
@@ -3,6 +3,7 @@ title: "Publishing Your Recipe Collection as a Website"
 date: 2026-02-28
 weight: 60
 summary: "Your .cook files are already structured data. Here's how to turn them into a real website — static, fast, free to host, and readable by Google's recipe search."
+description: "Your .cook files are already structured data. How to turn them into a real recipe website — static, fast, free to host, and readable by Google's recipe search."
 categories: ["Guides and Tutorials"]
 ---
 

--- a/content/blog/26-how-to-scale-recipes-without-mistakes.md
+++ b/content/blog/26-how-to-scale-recipes-without-mistakes.md
@@ -1,5 +1,5 @@
 ---
-title: "How to Scale a Recipe Up or Down (Without Ruining It)"
+title: "How to Scale a Recipe Up or Down Without Ruining It"
 date: 2026-02-28
 weight: 60
 summary: "Scaling recipes sounds like simple math until your cookies come out flat or your soup is inedibly salty. Here's why scaling fails and how to do it right."

--- a/content/blog/30-cooklang-playground-walkthrough.md
+++ b/content/blog/30-cooklang-playground-walkthrough.md
@@ -3,6 +3,7 @@ title: "Try Cooklang in Your Browser: Playground Walkthrough"
 date: 2026-02-28
 weight: 60
 summary: "The fastest way to try Cooklang requires nothing but a browser tab. This walkthrough shows you exactly what to expect when you open the playground."
+description: "The fastest way to try Cooklang needs nothing but a browser tab. A walkthrough of the online playground — what to type and what to expect."
 categories: ["Guides and Tutorials"]
 ---
 

--- a/content/blog/31-cooklang-for-food-bloggers.md
+++ b/content/blog/31-cooklang-for-food-bloggers.md
@@ -3,6 +3,7 @@ title: "Cooklang for Food Bloggers: Write Once, Publish Everywhere"
 date: 2026-02-28
 weight: 60
 summary: "One .cook file can generate your blog post, Google-ready Schema.org markup, a printable PDF, and a shopping list — without reformatting anything by hand."
+description: "One .cook file can generate your blog post, Schema.org markup, a printable PDF, and a shopping list — no reformatting. Cooklang for food bloggers."
 categories: ["Recipe Workflows"]
 ---
 

--- a/content/blog/33-plain-text-recipes-beginners-guide.md
+++ b/content/blog/33-plain-text-recipes-beginners-guide.md
@@ -3,6 +3,7 @@ title: "Plain Text Recipes: A Beginner's Guide to the Cooklang Format"
 date: 2026-03-11
 weight: 50
 summary: "A step-by-step introduction to writing recipes in Cooklang — the plain text format that turns your recipes into structured data. Convert your first recipe in five minutes."
+description: "A beginner's guide to plain-text recipes in the Cooklang format — turn recipes into structured data and write your first .cook file in five minutes."
 categories: ["Guides and Tutorials"]
 ---
 

--- a/content/blog/34-cooklang-mobile-app.md
+++ b/content/blog/34-cooklang-mobile-app.md
@@ -3,6 +3,7 @@ title: "Cooklang Mobile App: Read, Cook, and Shop from Your Phone"
 date: 2026-03-11
 weight: 50
 summary: "A walkthrough of the Cooklang mobile app for iOS and Android — how to set up your recipe collection, cook from your phone, and generate shopping lists on the go."
+description: "A walkthrough of the Cooklang mobile app for iOS and Android — set up your recipe collection, cook from your phone, and build shopping lists on the go."
 categories: ["Self-Hosting and Integrations"]
 ---
 

--- a/content/blog/35-recipe-markup-language.md
+++ b/content/blog/35-recipe-markup-language.md
@@ -3,6 +3,7 @@ title: "What Is a Recipe Markup Language? (And Why You'd Want One)"
 date: 2026-03-11
 weight: 50
 summary: "A markup language adds structure to text without making it unreadable. HTML does this for web pages. Cooklang does it for recipes. Here's what that means and why it matters for anyone who cooks."
+description: "A markup language adds structure to text without making it unreadable — HTML for web pages, Cooklang for recipes. What that means and why it matters for cooks."
 categories: ["Format and Design"]
 ---
 

--- a/content/blog/36-desktop-app-replaced-by-sync-agent.md
+++ b/content/blog/36-desktop-app-replaced-by-sync-agent.md
@@ -3,6 +3,7 @@ title: "The Desktop App Is Gone. Here's What Replaced It."
 date: 2026-03-11
 weight: 48
 summary: "We replaced the Cooklang desktop app with a lightweight sync agent — a tiny background service that does the same job faster, with less overhead."
+description: "Why we replaced the Cooklang desktop app with a lightweight sync agent — a tiny background service that does the same job faster, with less overhead."
 categories: ["Self-Hosting and Integrations"]
 ---
 

--- a/content/blog/38-plain-text-recipe-database.md
+++ b/content/blog/38-plain-text-recipe-database.md
@@ -3,6 +3,7 @@ title: "A Plain Text Recipe Database You Already Know How to Use"
 date: 2026-03-24
 weight: 46
 summary: "You don't need Postgres, schemas, or migrations to build a recipe database. Your filesystem already is one — and CookCLI gives you the query layer on top."
+description: "You don't need Postgres, schemas, or migrations for a recipe database — your filesystem already is one, and CookCLI gives you the query layer on top."
 categories: ["Self-Hosting and Integrations"]
 ---
 

--- a/content/blog/39-cooklang-editor-setup.md
+++ b/content/blog/39-cooklang-editor-setup.md
@@ -3,6 +3,7 @@ title: "Cooklang Editor Setup: VS Code, Vim, Obsidian, and More"
 date: 2026-03-24
 weight: 47
 summary: "Cooklang files are plain text, so any editor works. But syntax highlighting and LSP support make the experience much better. Here's how to set up your editor of choice."
+description: "Set up a Cooklang editor with syntax highlighting and LSP support — VS Code, Vim, Obsidian, and more. Any editor works, but these make it much nicer."
 categories: ["Guides and Tutorials"]
 ---
 

--- a/content/blog/43-version-control-recipes-with-git.md
+++ b/content/blog/43-version-control-recipes-with-git.md
@@ -3,6 +3,7 @@ title: "Version Control Your Recipes with Git"
 date: 2026-03-24
 weight: 50
 summary: "Every recipe app has a 'what if the company dies?' problem. If your recipes are plain text .cook files in a Git repo, that problem disappears. Here's how to set up a proper recipe repo, track changes meaningfully, collaborate with family, and publish to the Cooklang Federation."
+description: "Keep your recipes as plain-text .cook files in a Git repo and the 'what if the app dies?' problem disappears. Set up a recipe repo, track changes, and collaborate."
 categories: ["Recipe Workflows"]
 ---
 

--- a/content/blog/44-cooklang-parser-integration-guide.md
+++ b/content/blog/44-cooklang-parser-integration-guide.md
@@ -3,6 +3,7 @@ title: "Building with Cooklang: A Parser Integration Guide"
 date: 2026-03-24
 weight: 50
 summary: "You want structured recipe data — ingredients with quantities, steps with inline references, timers, cookware. Here's how to parse Cooklang in your language of choice, with quick-start examples in TypeScript and Python, and a map of the full ecosystem."
+description: "How to parse Cooklang in your language — ingredients, quantities, timers, cookware — with quick-start examples in TypeScript and Python and a map of the ecosystem."
 categories: ["Guides and Tutorials"]
 ---
 

--- a/content/blog/45-recipe-reports-and-dashboards.md
+++ b/content/blog/45-recipe-reports-and-dashboards.md
@@ -3,6 +3,7 @@ title: "Build Custom Recipe Reports with CookCLI and Templates"
 date: 2026-03-24
 weight: 50
 summary: "CookCLI has a template system that turns .cook files into shopping lists with store links, cost breakdowns, aisle-organized lists, and CSV exports. This post walks through the cook report command, the ingredient database, and real working templates."
+description: "Build custom recipe reports with CookCLI's template system — shopping lists with store links, cost breakdowns, aisle-organised lists, and CSV exports."
 categories: ["Guides and Tutorials"]
 ---
 

--- a/content/blog/48-best-recipe-management-software.md
+++ b/content/blog/48-best-recipe-management-software.md
@@ -1,5 +1,5 @@
 ---
-title: "Best Recipe Management Software in 2026: 9 Apps Compared Honestly"
+title: "Best Recipe Management Software in 2026: 9 Apps Tested & Compared"
 date: 2026-06-18
 weight: 46
 summary: "A practical guide to the best recipe management software in 2026 — from polished commercial apps like Paprika to self-hosted tools like Mealie to plain-text approaches like Cooklang. Honest about trade-offs."


### PR DESCRIPTION
Completes the SEO description sweep from the 2026-07-01 growth check-in. Content-only (front matter); no layout/CSS, so no Hugo rebuild needed.

- **19 meta descriptions** — every remaining blog post that lacked one now has a hand-written, keyword-led description (they were falling back to truncated auto-summaries). After this, **0 posts are missing a description**.
- **2 title tweaks** on high-impression pages (URL/slug unchanged, so rankings-by-URL are unaffected): `48-best-recipe` → '9 Apps Tested & Compared'; `26-scale-recipes` → dropped the parenthetical.
- Cross-site funnel links (cooklang.org meal-planning/grocery posts → cook.md's AI-planning & meal-kit posts) were already present — no over-linking added.